### PR TITLE
Center board and fix spacing

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -104,19 +104,24 @@ class Board
         @cells.select{ |coord, cell| !cell.fired_upon? }.keys
     end
 
-    def render(render_hidden_ship = false)
+    def render(is_player_board = false)
         render_string = "  "
-        (22-@dimension).times{render_string += " "}
+        (18-@dimension).times{render_string += " "}
         ("1"..@dimension.to_s).each do |column|
             render_string += "#{column} "
         end 
+        render_string += "   Key:" if is_player_board
         render_string += "\n"
         ("A"..(64 + @dimension).chr).each do |row|
-            (22-@dimension).times{render_string += " "}
+            (18-@dimension).times{render_string += " "}
             render_string += "#{row} "
             ("1"..@dimension.to_s).each do |column|
-                render_string += "#{@cells[row + column].render(render_hidden_ship)} "
+                render_string += "#{@cells[row + column].render(is_player_board)} "
             end
+            render_string += "   M: miss" if row == "A" && is_player_board
+            render_string += "   H: hit" if row == "B" && is_player_board
+            render_string += "   X: sunk ship" if row == "C" && is_player_board
+            render_string += "   S: afloat ship" if row == "D" && is_player_board
             render_string += "\n"
         end
         render_string  

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -106,11 +106,13 @@ class Board
 
     def render(render_hidden_ship = false)
         render_string = "  "
+        (22-@dimension).times{render_string += " "}
         ("1"..@dimension.to_s).each do |column|
             render_string += "#{column} "
         end 
         render_string += "\n"
         ("A"..(64 + @dimension).chr).each do |row|
+            (22-@dimension).times{render_string += " "}
             render_string += "#{row} "
             ("1"..@dimension.to_s).each do |column|
                 render_string += "#{@cells[row + column].render(render_hidden_ship)} "

--- a/lib/computer.rb
+++ b/lib/computer.rb
@@ -27,7 +27,6 @@ class Computer
       coordinates = []
 
       until @board.valid_placement?(ship, coordinates)
-        # coordinates[0] = (65 + rand(4)).chr + (1 + rand(4)).to_s 
         coordinates[0] = @board.cells.select{ |coord, cell| cell.empty? }.values.sample.coordinate
         across = rand(2) == 1
         (ship.length - 1).times do |i|

--- a/lib/computer.rb
+++ b/lib/computer.rb
@@ -53,7 +53,6 @@ class Computer
     fire_coord = heatmap.max_by{ |coord, value| value }.first
     result = @player.board.cells[fire_coord].fire_upon
     puts "My shot on #{fire_coord} was a #{result}."
-    puts 
   end
 
   # heatmap_with_hits

--- a/lib/game_round.rb
+++ b/lib/game_round.rb
@@ -87,11 +87,15 @@ class GameRound
   end
 
   def game_over
+    puts
     puts "===============COMPUTER'S BOARD==============="
+    puts
     puts @computer.board.render
+    puts
     puts players_board_header 
+    puts
     puts @player.board.render(true)
-    puts ""
+    puts 
     if @computer.all_ships_sunk?
       puts "You won!"
     else

--- a/lib/game_round.rb
+++ b/lib/game_round.rb
@@ -54,11 +54,15 @@ class GameRound
   end
 
   def take_turn
+    puts
     puts "===============COMPUTER'S BOARD==============="
-    puts @computer.board.render #=> rendering ships now for testing, final product should remove (true)
+    puts
+    puts @computer.board.render
+    puts
     puts players_board_header
+    puts
     puts @player.board.render(true)
-    puts ""
+    puts 
 
     @player.fire
     @computer.fire

--- a/lib/game_round.rb
+++ b/lib/game_round.rb
@@ -88,8 +88,8 @@ class GameRound
 
   def game_over
     puts "===============COMPUTER'S BOARD==============="
-    puts @computer.board.render(true) #=> rendering ships now for testing, final product should remove (true)
-    puts players_board_header # puts "=============#{@player.name} BOARD============="
+    puts @computer.board.render
+    puts players_board_header 
     puts @player.board.render(true)
     puts ""
     if @computer.all_ships_sunk?

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -51,6 +51,7 @@ class Player
             selection = gets.chomp.upcase
         end
         result = @computer.board.cells[selection].fire_upon
+        puts
         puts "Your shot on #{selection} was a #{result}." 
     end
 


### PR DESCRIPTION
Slightly modified board.render method to add spaces at the beginning so the board is centered under the header.
This is dynamic depending on the size of the board.
Added a key to the player's version of the board(when true is passed to the .render method)
Also added spacing above and below board when puts to terminal.
Removed some old unnecessary comments.